### PR TITLE
Makefile: Fix driver debug log level

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ CONFIG_RTW_IOT_CCK_PD_INIT = n
 CONFIG_RTW_DEBUG = y
 # default log level is _DRV_INFO_ = 4,
 # please refer to "How_to_set_driver_debug_log_level.doc" to set the available level.
-CONFIG_RTW_LOG_LEVEL = 4
+CONFIG_RTW_LOG_LEVEL = 2
 ######################## Wake On Lan ##########################
 CONFIG_WOWLAN = n
 #bit2: deauth, bit1: unicast, bit0: magic pkt.


### PR DESCRIPTION
Fix driver debug log level to avoid unnecessary messages
flooding the console.

Signed-off-by: Suniel Mahesh <sunil@amarulasolutions.com>